### PR TITLE
Release v2.0.37: Adding browse_impression event in analytics

### DIFF
--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -274,10 +274,8 @@ if (location.pathname === "/men") {
 }
 
 window.unbxdSearch = new UnbxdSearch({
-    siteKey: "prod-frenchbedroomcompany11861619415887",
-    apiKey: "62f8c3f47421a605fc5d1d1be55ae936",
-    // siteKey: "demo-unbxd700181503576558",
-    // apiKey: "fb853e3332f2645fac9d71dc63e09ec1",
+    siteKey: "demo-unbxd700181503576558",
+    apiKey: "fb853e3332f2645fac9d71dc63e09ec1",
     updateUrls: true,
     hashMode: true,
     searchBoxEl: document.getElementById("unbxdInput"),

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -274,10 +274,12 @@ if (location.pathname === "/men") {
 }
 
 window.unbxdSearch = new UnbxdSearch({
-    siteKey: "demo-unbxd700181503576558",
-    apiKey: "fb853e3332f2645fac9d71dc63e09ec1",
+    siteKey: "prod-frenchbedroomcompany11861619415887",
+    apiKey: "62f8c3f47421a605fc5d1d1be55ae936",
+    // siteKey: "demo-unbxd700181503576558",
+    // apiKey: "fb853e3332f2645fac9d71dc63e09ec1",
     updateUrls: true,
-    hashMode: false,
+    hashMode: true,
     searchBoxEl: document.getElementById("unbxdInput"),
     searchTrigger: "click",
     searchButtonEl: document.getElementById("searchBtn"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unbxd-ui/vanilla-search-library",
-  "version": "2.0.36",
+  "version": "2.0.37",
   "description": "A JavaScript library for building performant and quick search experiences with Unbxd",
   "main": "public/dist/js/vanillaSearch.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-// import UnbxdSearchCore from "../../search-JS-core/src/index";
-import UnbxdSearchCore from "@unbxd-ui/unbxd-search-core";
+import UnbxdSearchCore from "../../search-JS-core/src/index";
+// import UnbxdSearchCore from "@unbxd-ui/unbxd-search-core";
 import styles from '../styles/index.scss';
 import delegate from "./modules/utils/delegate";
 import options from './common/options';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import UnbxdSearchCore from "../../search-JS-core/src/index";
-// import UnbxdSearchCore from "@unbxd-ui/unbxd-search-core";
+// import UnbxdSearchCore from "../../search-JS-core/src/index";
+import UnbxdSearchCore from "@unbxd-ui/unbxd-search-core";
 import styles from '../styles/index.scss';
 import delegate from "./modules/utils/delegate";
 import options from './common/options';

--- a/src/modules/analytics/setAnalytics.js
+++ b/src/modules/analytics/setAnalytics.js
@@ -33,9 +33,7 @@ const trackImpression = function(){
     let obj = { 
         'pids_list' : []
     };
-    if(productType ==="SEARCH") {
-        obj['query'] = query;
-    }
+    
     if(products) {
         let pids = [];
         products.forEach(product => {
@@ -47,7 +45,16 @@ const trackImpression = function(){
             pids.push(pid)
         });
         obj['pids_list'] = pids;
-        Unbxd.track('search_impression',obj);  
+        if(productType ==="SEARCH") {
+            obj['query'] = query;
+            Unbxd.track('search_impression',obj);  
+        } else if(productType ==="CATEGORY" || productType ==="BROWSE") {
+            if(window.UnbxdAnalyticsConf){
+                obj['page'] = window.UnbxdAnalyticsConf.page || "";
+                obj['page_type'] = window.UnbxdAnalyticsConf.page_type || "";
+            }
+            Unbxd.track('browse_impression',obj);  
+        }
     }
 }
 const trackFacetClick = function(state,type){


### PR DESCRIPTION
The Product Impression event was not being tracked for all the Category pages until now, This has been fixed by introducing the `browse_impression` event in the analytics.