### PR TITLE
Feature 2.1.6

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,22 @@ nav_order: 9
 {:toc}
 
 ---
+
+# v2.1.6
+
+- **Release Date**: 24th Apr, 2024
+- **Core SDK Version**: v0.5.8
+- **CDN Link**: [https://libraries.unbxdapi.com/search-sdk/v2.1.6/vanillaSearch.min.js](https://libraries.unbxdapi.com/search-sdk/v2.1.6/vanillaSearch.min.js)
+
+## 🐛 Bug Fixes
+{: .no_toc}
+
+- Resolved issue regarding uc_param , where it was not being retained in the url on reload of the page.
+- Fixed a problem where the last page button in pagination was not directing to the last page. 
+- Implemented additional try-catch blocks for better debugging within UnbxdSearch methods.
+- Addressed an issue where, in the case of seoFriendlyUrl being true and a keyValueSeparator other than = being passed, the category string was not properly appended to the URL. This issue is resolved in this release.
+
+---
 # v2.1.5
 
 - **Release Date**: 5th Mar, 2024

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@unbxd-ui/vanilla-search-library",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "description": "A JavaScript library for building performant and quick search experiences with Unbxd",
     "main": "public/dist/js/vanillaSearch.js",
     "repository": {
@@ -74,7 +74,7 @@
     "author": "Unbxd",
     "license": "ISC",
     "dependencies": {
-        "@unbxd-ui/unbxd-search-core": "0.5.7",
+        "@unbxd-ui/unbxd-search-core": "0.5.8",
         "babel-polyfill": "^6.26.0",
         "babel-runtime": "^6.26.0",
         "element-dataset": "^2.2.6"

--- a/src/core/reRender.js
+++ b/src/core/reRender.js
@@ -1,3 +1,5 @@
+import { events } from "../common/constants";
+
 const reRender = function () {
     const {
         onEvent,
@@ -20,8 +22,13 @@ const reRender = function () {
         afterNoResultRender,
         afterRender
     } = this.events;
-
-    onEvent(this, beforeRender);
+    
+    try{
+        onEvent(this, beforeRender);
+    }catch(error){
+        this.onError("reRender", error, events.runtimeError);
+    }
+    
 
     if (loader.el) {
         loader.el.innerHTML = ``;
@@ -52,7 +59,12 @@ const reRender = function () {
         if (Object.keys(redirect).length) {
             return;
         }
-        onEvent(this, beforeNoResultRender);
+        try {
+            onEvent(this, beforeNoResultRender);
+        }catch(error){
+            this.onError("reRender", error, events.runtimeError);
+        }
+       
         this.viewState.noResultLoaded = true;
         
         if(this.options.noResults?.el) {
@@ -67,7 +79,13 @@ const reRender = function () {
         if (!qParams.filter) {
             this.renderFacets();
         }
-        onEvent(this, afterNoResultRender);
+        
+        try{
+            onEvent(this, afterNoResultRender);
+        }catch(error){
+            this.onError("reRender", error, events.runtimeError);
+        }
+       
     } else {
         this.renderProducts();
         
@@ -99,7 +117,12 @@ const reRender = function () {
         });
     } 
 
-    onEvent(this, afterRender);
+    try{
+        onEvent(this, afterRender);
+    }catch(error){
+        this.onError("reRender", error, events.runtimeError);
+    }
+   
 
 
 };

--- a/src/index.js
+++ b/src/index.js
@@ -73,20 +73,35 @@ class UnbxdSearch extends UnbxdSearchCore {
             this.options.extraParams.viewType = viewType;
         }
         if(type === beforeApiCall) { 
-            onEvent(this,beforeApiCall);
+            try{
+                onEvent(this, beforeApiCall);
+            }catch(error){
+                this.onError("callback", error, events.runtimeError);
+            }
+            
             if(loader && loader.el) {
                 loader.el.innerHTML = loader.template(this);
             }
         }
         if(type === afterApiCall) { 
-            onEvent(this,afterApiCall);
+            try{
+                onEvent(this, afterApiCall);
+            }catch(error){
+                this.onError("callback", error, events.runtimeError);
+            }
+            
             if(this.state.products.length > 0) {
                 this.viewState.noResultLoaded = false;
             }
             this.reRender();
         }
         if((type === 'added_facet' || type === 'deleted_facet' ) && facet.applyMultipleFilters) {
-            onEvent(this,'added_facet');
+            try{
+                onEvent(this, 'added_facet');
+            }catch(error){
+                this.onError("callback", error, events.runtimeError);
+            }
+            
             this.renderFacets();
         }
         if(type === "FETCH_ERROR") {

--- a/src/modules/pagination/actions.js
+++ b/src/modules/pagination/actions.js
@@ -60,7 +60,7 @@ function renderNewResults(action) {
                 }
             }
             
-            if(action === this.action.lastPage){
+            if(action === this.actions.lastPage){
                 const lastPage = (noOfPages - 1) * rows;
                 if(isNext){
                     this.viewState.lastAction = "pagination";

--- a/src/modules/pagination/paginationUI.js
+++ b/src/modules/pagination/paginationUI.js
@@ -54,9 +54,11 @@ const paginationUI = function (paginationData, pagination) {
     }
     if(!isNext) {
         nextBtn = `<button disabled class="UNX-next-btn UNX-page-next">></button>`;
+        lastPageBtn = `<button disabled class="UNX-next-btn UNX-page-next">>></button>`
     }
     if(!isPrev) {
         prevBtn = `<button disabled class="UNX-prev-btn UNX-page-prev"><</button>`;
+        firstPageBtn = `<button disabled class="UNX-prev-btn UNX-page-next"><<</button>`;
     }
     return [`<div class="UNX-pagination-block">`,
         firstPageBtn,


### PR DESCRIPTION
- Resolved issue regarding uc_param , where it was not being retained in the url on reload of the page.
- Fixed a problem where the last page button in pagination was not directing to the last page. 
- Implemented additional try-catch blocks for better debugging within UnbxdSearch methods.
- Addressed an issue where, in the case of seoFriendlyUrl being true and a keyValueSeparator other than = being passed, the category string was not properly appended to the URL. This issue is resolved in this release.